### PR TITLE
격자좌표 기준으로 캐싱하도록 수정

### DIFF
--- a/src/forecast/forecast.service.ts
+++ b/src/forecast/forecast.service.ts
@@ -16,12 +16,14 @@ import { FCST_TIMES } from './forecast.interface';
 @Injectable()
 export class ForecastService {
   private readonly redis: Redis;
+  private cachedGrid: Set<string>;
   constructor(
     private configService: ConfigService,
     private redisService: RedisService,
     private contentsService: ContentsService,
   ) {
     this.redis = this.redisService.getClient();
+    this.cachedGrid = new Set<string>();
   }
 
   public async handleSqsEvent(event): Promise<void> {
@@ -32,13 +34,18 @@ export class ForecastService {
     const jobQueue: Array<Promise<boolean>> = [];
     for (const record of event.Records) {
       const infor = JSON.parse(record.body);
-      const { code, x, y } = infor.data;
-      const redisKey = `${code}:${baseDate}`;
-      jobQueue.push(
-        this.processWeatherInformation(x, y, baseDate, baseTime, redisKey),
-      );
+      const { x, y } = infor.data;
+      const grid = `${String(x).padStart(3, '0')}${String(y).padStart(3, '0')}`;
+      if (!this.cachedGrid.has(grid)) {
+        this.cachedGrid.add(grid);
+        const redisKey = `${grid}:${baseDate}`;
+        jobQueue.push(
+          this.processWeatherInformation(x, y, baseDate, baseTime, redisKey),
+        );
+      }
     }
     await Promise.allSettled(jobQueue);
+    this.cachedGrid.clear();
   }
 
   private async processWeatherInformation(


### PR DESCRIPTION
Close #33 

## 작업 내용
- Redis 키값 `격자:baseDate(:content)` 로 저장되도록 수정
  - (참고) 격자 정보는 3자리 미만일 경우 앞자리 0으로 채워 x(3) + y(3) 총 6자리로 키값 생성

## 주의 사항
- 테스트 못해봄 😅 코드 리뷰 필요•••
- ~~앱 서버 키값 가져오는 부분들 수정 필요~~ (수정함)